### PR TITLE
Feature: Blacklisted words

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ https://1.1.1.1:443/a.js?
 https://1.1.1.1:443/a.jpg
 https://1.1.1.1:8443/
 https://1.1.1.1:443/
+https://1.1.1.1:443/node_modules/exec.js
 arch ~>  cat test_urls.txt | godeclutter -b -c -p
 https://1.1.1.1/
 https://1.1.1.1:8443/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ godeclutter will perform the following steps on your URL host section:
 - Clean port notation of URLs pointing to the default protocol ports, since those ports are already implied by the protocol scheme. (such as :443 and :80)
 - Clean http:// URLs if a https:// to the same host and port is present, since 99,9% of those cases will just be a redirect to https://.
 - Remove uninteresting media extensions such as png, jpg, css, etc. (This one will keep .js files since those are sometimes interesting)
+- Remove urls with uninteresting words such as bootstrap, jquery, node_modules, etc.
 - Sort query parameters
 - Lowercase all schemes and hostnames, since upper-casing is irrelevant for those.
 - Replace all lower-case URI encoding escapes to upper-case, to maintain a standard.
@@ -71,7 +72,8 @@ arch ~>
 ```bash
 $> ./godeclutter -h
 Usage of ./godeclutter:
-  -b	Blacklist Extensions - clean some uninteresting extensions. (default true)
+  -be	Blacklist Extensions - clean some uninteresting extensions. (default true)
+  -bw	Blacklist words - clean some uninteresting words. (default true)
   -c	Clean URLs - Aggressively clean/normalize URLs before outputting them.
   -p	Prefer HTTPS - If there's a https url present, don't print the http for it. (since it will probably just redirect to https)
 ```

--- a/godeclutter.go
+++ b/godeclutter.go
@@ -15,9 +15,11 @@ import (
 // var strFlag = flag.String("long-string", "", "Description")
 var preferHttpsFlag = flag.Bool("p", false, "Prefer HTTPS - If there's a https url present, don't print the http for it. (since it will probably just redirect to https)")
 var normalizeURLFlag = flag.Bool("c", true, "Clean URLs - Aggressively clean/normalize URLs before outputting them.")
-var blacklistExtensionsFlag = flag.Bool("b", true, "Blacklist Extensions - clean some uninteresting extensions.")
+var blacklistExtensionsFlag = flag.Bool("be", true, "Blacklist Extensions - clean some uninteresting extensions.")
+var blacklistWordsFlag = flag.Bool("bw", true, "Blacklist Words - clean some uninteresting words.")
 
 var blacklistedExtensions = []string{"css", "png", "jpg", "jpeg", "svg", "ico", "webp", "ttf", "otf", "woff", "gif", "pdf", "bmp", "eot", "mp3", "woff2", "mp4", "avi"}
+var blacklistedWords = []string("node_modules", "jquery", "bootstrap", "wp-includes")
 
 func iterInput(c chan string) {
 	scanner := bufio.NewScanner(os.Stdin)
@@ -132,14 +134,27 @@ func main() {
 		}
 
 		if *blacklistExtensionsFlag {
-			foundBlacklisted := false
+			foundBlacklistedExtension := false
 			for _, ext := range blacklistedExtensions {
 				if strings.HasSuffix(u.Path, ext) {
-					foundBlacklisted = true
+					foundBlacklistedExtension = true
 					continue
 				}
 			}
-			if foundBlacklisted {
+			if foundBlacklistedExtension {
+				continue
+			}
+		}
+
+		if *blacklistWordsFlag {
+			foundBlacklistedWord := false
+			for _, word := range blacklistedWords {
+				if strings.Contains(u.Path, word) {
+					foundBlacklistedWord = true
+					continue
+				}
+			}
+			if foundBlacklistedWord {
 				continue
 			}
 		}

--- a/godeclutter.go
+++ b/godeclutter.go
@@ -19,7 +19,7 @@ var blacklistExtensionsFlag = flag.Bool("be", true, "Blacklist Extensions - clea
 var blacklistWordsFlag = flag.Bool("bw", true, "Blacklist Words - clean some uninteresting words.")
 
 var blacklistedExtensions = []string{"css", "png", "jpg", "jpeg", "svg", "ico", "webp", "ttf", "otf", "woff", "gif", "pdf", "bmp", "eot", "mp3", "woff2", "mp4", "avi"}
-var blacklistedWords = []string("node_modules", "jquery", "bootstrap", "wp-includes")
+var blacklistedWords = []string{"node_modules", "jquery", "bootstrap", "wp-includes"}
 
 func iterInput(c chan string) {
 	scanner := bufio.NewScanner(os.Stdin)

--- a/test_urls.txt
+++ b/test_urls.txt
@@ -24,3 +24,5 @@ https://1.1.1.1:443/a.js?
 https://1.1.1.1:443/a.jpg
 https://1.1.1.1:8443/
 https://1.1.1.1:443/
+https://1.1.1.1:443/node_modules/
+https://1.1.1.1:443/path/scripts/jquery.js


### PR DESCRIPTION
Proposal to add a feature that ignores files/paths with certain words. Jquery, boostrap and files under node_modules are usually unwanted and should not be a problem if they were ignored or cleaned.

---

**Flag name:** `bw`, stands for blacklist words. Other flags were renamed to keep a pattern, so was variable names.

`test_urls.txt` was edited to add this feature examples. 
`README` was edited to add this feature flag explanation.

---

## Ideas for future implementations:

**Idea:** Make this feature allow custom input data, where the user would append or replace the words by their own. 
**Reason:** Some assets use specific words that are often unwanted, this flag would give the possibily to make niche based custom declutter
